### PR TITLE
Enable env passthrough at runtime for docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM nginx:1.12-alpine
-ARG PREFIX
-COPY ./out /usr/share/nginx/html/${PREFIX:-sigcom}/
+
+COPY ./entrypoint.sh /entrypoint.sh
+RUN set -x && chmod +x /entrypoint.sh
+
+COPY ./out /sigcom
+
 EXPOSE 80
+
+ENTRYPOINT [ "/entrypoint.sh" ]
 CMD ["nginx", "-g", "daemon off;"]

--- a/components/Admin/index.js
+++ b/components/Admin/index.js
@@ -23,7 +23,7 @@ import Fingerprint from '@material-ui/icons/Fingerprint'
 import LibraryBooks from '@material-ui/icons/LibraryBooks'
 import JssProvider from 'react-jss/lib/JssProvider'
 
-import { base_url, fetch_meta, fetch_creds } from '../../util/fetch/meta'
+import { fetch_meta, fetch_creds } from '../../util/fetch/meta'
 import { fetchJson, patchJson } from '../../util/fetch/fetch'
 
 import loopbackProvider from './loopback-provider'
@@ -38,6 +38,7 @@ import { MyLogin } from './Login.js'
 import { generateClassName } from './classNameGenerator.js'
 
 class AdminView extends React.PureComponent {
+  // <Lazy>{async () => <AdminView base_url={await base_url()} ... />}</Lazy>
   constructor(props) {
     super(props)
     const token = process.env.NODE_ENV === 'development' ? process.env.NEXT_PUBLIC_CREDS : ''
@@ -54,7 +55,7 @@ class AdminView extends React.PureComponent {
       signature_fields: props.signature_keys[Object.keys(props.signature_keys)[0]],
       hash: window.location.hash,
     }
-    this.dataProvider = loopbackProvider(base_url, this.httpClient)
+    this.dataProvider = loopbackProvider(this.props.base_url, this.httpClient)
   }
 
   longTextInputFormat = (v) => typeof v === 'object' ? JSON.stringify(v, null, 2) : v

--- a/components/Home/index.js
+++ b/components/Home/index.js
@@ -24,6 +24,7 @@ import { base_url as meta_url } from '../../util/fetch/meta'
 import { base_url as data_url } from '../../util/fetch/data'
 import { closeSnackBar, initializeTheme } from '../../util/redux/actions'
 import '../../styles/swagger.scss'
+import Lazy from '../Lazy'
 const SwaggerUI = dynamic(() => import('swagger-ui-react'), { ssr: false })
 
 
@@ -118,20 +119,24 @@ class Home extends React.PureComponent {
   api = (props) => (
     <Grid container>
       <Grid xs={12} lg={6}>
-        <SwaggerUI
-          url={`${meta_url}/openapi.json`}
-          deepLinking={true}
-          displayOperationId={true}
-          filter={true}
-        />
+        <Lazy>{async () => (
+          <SwaggerUI
+            url={`${await meta_url()}/openapi.json`}
+            deepLinking={true}
+            displayOperationId={true}
+            filter={true}
+          />
+        )}</Lazy>
       </Grid>
       <Grid xs={12} lg={6}>
-        <SwaggerUI
-          url={`${data_url}/swagger.yml`}
-          deepLinking={true}
-          displayOperationId={true}
-          filter={true}
-        />
+        <Lazy>{async () => (
+          <SwaggerUI
+            url={`${await data_url()}/swagger.yml`}
+            deepLinking={true}
+            displayOperationId={true}
+            filter={true}
+          />
+        )}</Lazy>
       </Grid>
     </Grid>
   )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+if [ -z "${PREFIX}" ]; then
+  echo "deprecation warning: `PREFIX` environment variable should be specified explicitly"
+  export PREFIX="/sigcom"
+fi
+
+if [ ! -z "${NEXT_PUBLIC_ENRICHR_URL}" ]; then
+  export NEXT_PUBLIC_ENRICHR_URL="https://amp.pharm.mssm.edu/Enrichr/"
+fi
+
+echo "Mounting sigcom on ${PREFIX}..."
+
+mkdir -p /usr/share/nginx/html/
+
+
+# runtime config for website
+
+cat > /sigcom/static/config.json << EOF
+{
+  "NEXT_PUBLIC_METADATA_API": "${NEXT_PUBLIC_METADATA_API}",
+  "NEXT_PUBLIC_DATA_API": "${NEXT_PUBLIC_DATA_API}",
+  "NEXT_PUBLIC_ENRICHR_URL": "${NEXT_PUBLIC_ENRICHR_URL}"
+}
+EOF
+
+# link sigcom into nginx directory
+ln -s /sigcom /usr/share/nginx/html${PREFIX}
+
+exec "$@"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "signature-commons-ui",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signature-commons-ui",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "private": true,
   "homepage": "https://amp.pharm.mssm.edu/sigcom/",
   "dependencies": {

--- a/util/config.js
+++ b/util/config.js
@@ -1,0 +1,17 @@
+let _config = undefined
+
+export default async function config() {
+  try {
+    if (_config === undefined) {
+      _config = await (await fetch('./static/config.json')).json()
+    }
+    return _config
+  } catch {
+    console.warn('Could not load config, using fallback')
+    return {
+      NEXT_PUBLIC_METADATA_API: process.env.NEXT_PUBLIC_METADATA_API !== undefined ? process.env.NEXT_PUBLIC_METADATA_API : (window.location.origin + '/signature-commons-metadata-api'),
+      NEXT_PUBLIC_DATA_API: process.env.NEXT_PUBLIC_DATA_API !== undefined ? process.env.NEXT_PUBLIC_DATA_API : (window.location.origin + '/enrichmentapi'),
+      NEXT_PUBLIC_ENRICHR_URL: 'https://amp.pharm.mssm.edu/Enrichr',
+    }
+  }
+}

--- a/util/fetch/data.js
+++ b/util/fetch/data.js
@@ -1,17 +1,19 @@
 import fetch from 'isomorphic-unfetch'
+import config from '../config'
 
-export const base_url = process.env.NEXT_SERVER_DATA_API
-  || process.env.NEXT_STATIC_DATA_API
-  || process.env.NEXT_PUBLIC_DATA_API
-  || (window.location.origin + '/enrichmentapi')
+export async function base_url() {
+  return (await config()).NEXT_PUBLIC_DATA_API
+}
 
-export const base_versioned_url = base_url + '/api/v1'
+export async function base_versioned_url() {
+  return (await base_url()) + '/api/v1'
+}
 
 export async function fetch_data({ endpoint, body, signal }) {
   const start = new Date()
 
   const request = await fetch(
-      base_versioned_url
+      (await base_versioned_url())
     + (endpoint === undefined ? '' : endpoint),
       {
         method: 'POST',
@@ -20,7 +22,7 @@ export async function fetch_data({ endpoint, body, signal }) {
       }
   )
   if (request.ok !== true) {
-    throw new Error(`Error communicating with API at ${base_versioned_url}${endpoint}`)
+    throw new Error(`Error communicating with API at ${await base_versioned_url()}${endpoint}`)
   }
 
   let response_text = (await request.text()).replace(/Infinity/g, 'null')

--- a/util/fetch/meta.js
+++ b/util/fetch/meta.js
@@ -1,14 +1,17 @@
 import fetch from 'isomorphic-unfetch'
+import config from '../config'
 
-export const base_url = process.env.NEXT_SERVER_METADATA_API
-  || process.env.NEXT_STATIC_METADATA_API
-  || process.env.NEXT_PUBLIC_METADATA_API
-  || (window.location.origin + '/signature-commons-metadata-api')
-export const base_scheme = /^(https?):\/\/.+/.exec(base_url)[1]
+export async function base_url() {
+  return (await config()).NEXT_PUBLIC_METADATA_API
+}
+
+export async function base_scheme() {
+  return /^(https?):\/\/.+/.exec(await base_url())[1]
+}
 
 export async function fetch_creds({ endpoint, body, signal, headers }) {
   const request = await fetch(
-      base_url
+      (await base_url())
     + (endpoint === undefined ? '' : endpoint)
     + (body === undefined ? '' : (
         '?'
@@ -48,7 +51,7 @@ export async function fetch_meta({ endpoint, body, signal, headers }) {
   const start = new Date()
 
   const request = await fetch(
-      base_url
+      (await base_url())
     + (endpoint === undefined ? '' : endpoint)
     + (body === undefined ? '' : (
         '?'
@@ -73,7 +76,7 @@ export async function fetch_meta({ endpoint, body, signal, headers }) {
       }
   )
   if (request.ok !== true) {
-    throw new Error(`Error communicating with API at ${base_url}${endpoint}`)
+    throw new Error(`Error communicating with API at ${await base_url()}${endpoint}`)
   }
 
   const response = await request.json()
@@ -104,7 +107,7 @@ export async function fetch_meta({ endpoint, body, signal, headers }) {
 export async function fetch_meta_post({ endpoint, body, signal }) {
   const start = new Date()
   const request = await fetch(
-      base_url
+      (await base_url())
     + (endpoint === undefined ? '' : endpoint),
       {
         method: 'POST',
@@ -118,7 +121,7 @@ export async function fetch_meta_post({ endpoint, body, signal }) {
       }
   )
   if (request.ok !== true) {
-    throw new Error(`Error communicating with API at ${base_url}${endpoint}`)
+    throw new Error(`Error communicating with API at ${await base_url()}${endpoint}`)
   }
 
   const response = await request.json()


### PR DESCRIPTION
This patch enables the following environment variables to be configured at runtime:

- `PREFIX`: (where to mount the image, default: `/sigcom`)
- `NEXT_PUBLIC_METADATA_API`: The public URL that clients should use to reach the metadata api
- `NEXT_PUBLIC_DATA_API`: The public URL that clients should use to reach the data api
- `NEXT_PUBLIC_ENRICHR_URL`: The public URL that clients should use to reach enrichr